### PR TITLE
fix invalid markdown links

### DIFF
--- a/src/collections/_documentation/clients/javascript/sourcemaps.md
+++ b/src/collections/_documentation/clients/javascript/sourcemaps.md
@@ -18,4 +18,4 @@ Raven.config('your-dsn', {
 ```
 ## Next Steps
 
-Now that you've specified the release in your SDK config, head on over to [our main source maps docs]({%- link _documentation/platforms/javascript/sourcemaps/index.md -%}) to learn how to [create your source maps]([there]({%- link _documentation/platforms/javascript/sourcemaps/generation.md -%})) and [make them available to Sentry]([there]({%- link _documentation/platforms/javascript/sourcemaps/availability.md -%})). There you'll also find a [troubleshooting guide]([there]({%- link _documentation/platforms/javascript/sourcemaps/troubleshooting.md -%})).
+Now that you've specified the release in your SDK config, head on over to [our main source maps docs]({%- link _documentation/platforms/javascript/sourcemaps/index.md -%}) to learn how to [create your source maps]({%- link _documentation/platforms/javascript/sourcemaps/generation.md -%}) and [make them available to Sentry]({%- link _documentation/platforms/javascript/sourcemaps/availability.md -%}). There you'll also find a [troubleshooting guide]({%- link _documentation/platforms/javascript/sourcemaps/troubleshooting.md -%}).


### PR DESCRIPTION
address broken links on javascript sourcemaps page (I'm not sure if the same error is not present on other pages)
<img width="1026" alt="screenshot 2018-12-31 at 14 11 43" src="https://user-images.githubusercontent.com/2434839/50559361-411f1900-0d07-11e9-8108-c812777ae568.png">
